### PR TITLE
Several enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The following parsing operations are currently supported
     // "a" followed by "b"
     let rule = "a" ~ "b"
 
+	// "a" followed by "b", with possible whitespace in between
+	// to change what is considered whitespace, change the parser.whitespace rule
+	let rule = "a" ~~ "b"
+
+	// at least one "a", but possibly more
+	let rule = "a"++
+
     // "a" or "b"
     let rule = "a" | "b"
 

--- a/SwiftParser.xcodeproj/project.pbxproj
+++ b/SwiftParser.xcodeproj/project.pbxproj
@@ -381,7 +381,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = SwiftParser/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				INSTALL_PATH = "@executable_path/../Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -400,7 +400,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = SwiftParser/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				INSTALL_PATH = "@executable_path/../Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/SwiftParser/Parser.swift
+++ b/SwiftParser/Parser.swift
@@ -231,6 +231,7 @@ public func | (left: ParserRule, right: ParserRule) -> ParserRule {
         let pos = reader.position
         var result = left(parser: parser, reader: reader)
         if(!result) {
+			reader.seek(pos)
             result = right(parser: parser, reader: reader)
         }
     

--- a/SwiftParser/Parser.swift
+++ b/SwiftParser/Parser.swift
@@ -312,6 +312,11 @@ public func ~~ (left : ParserRule, right: ParserRule) -> ParserRule {
 	}
 }
 
+/** Parser rule that matches the given parser rule at least once, but possibly more */
+public postfix func ++ (left: ParserRule) -> ParserRule {
+	return left ~~ left*
+}
+
 public typealias ParserRuleDefinition = () -> ParserRule
 infix operator <- {}
 public func <- (left: Parser, right: ParserRuleDefinition) -> () {

--- a/SwiftParser/Parser.swift
+++ b/SwiftParser/Parser.swift
@@ -299,15 +299,17 @@ public func <- (left: Parser, right: ParserRuleDefinition) -> () {
 }
 
 public class Parser {
-    struct ParserCapture : CustomStringConvertible {
+    public struct ParserCapture : CustomStringConvertible {
         var start: Int
         var end: Int
         var action: ParserAction
         let reader:Reader
-        var text:String {
+
+		var text: String {
             return reader.substring(start, ending_at:end)
         }
-        var description: String {
+
+        public var description: String {
             return "[\(start),\(end):\(text)]"
         }
     }
@@ -316,11 +318,13 @@ public class Parser {
     public var rule_definitions: [ParserRuleDefinition] = []
     public var start_rule: ParserRule?
     public var debug_rules = false
-    var captures: [ParserCapture] = []
-    var current_capture:ParserCapture?
-    var last_capture:ParserCapture?
-    var current_reader:Reader?
-    var named_rules: Dictionary<String,ParserRule> = Dictionary<String,ParserRule>()
+
+    public var captures: [ParserCapture] = []
+    public var current_capture:ParserCapture?
+    public var last_capture:ParserCapture?
+    public var current_reader:Reader?
+
+	var named_rules: Dictionary<String,ParserRule> = Dictionary<String,ParserRule>()
     var current_named_rule = ""
 
     public var text:String {

--- a/SwiftParser/Parser.swift
+++ b/SwiftParser/Parser.swift
@@ -303,6 +303,9 @@ public class Parser {
         var start: Int
         var end: Int
         var action: ParserAction
+        public var start: Int
+        public var end: Int
+        public var action: ParserAction
         let reader:Reader
 
 		var text: String {


### PR DESCRIPTION
This pull request contains several enhancements:
- The 'framework path' of the library is now set to @excutable_path/../Frameworks, which is the default location for Frameworks bundled with apps
- Captures of the parser are now public, so that they can be used for syntax highlighting
- There is a new 'follows by' operator ("~~") that allows for whitespace in between two items (what is considered whitespace can be set by changing the Parser.whitespace rule)
- There is a new 'match at least once'  operator ("++") that matches a rule at least once, but possibly more than once.
- A fix for the alternative operator ("|") incorrectly backtracking.
