### PR TITLE
Fix build on Linux (disables regular expressions on Linux for now)

### DIFF
--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -45,6 +45,7 @@ public prefix func ^(name:String) -> ParserRule {
 }
 
 // match a regex
+#if !os(Linux)
 prefix operator %!
 public prefix func %!(pattern:String) -> ParserRule {
     return {(parser: Parser, reader: Reader) -> Bool in
@@ -66,7 +67,7 @@ public prefix func %!(pattern:String) -> ParserRule {
                 parser.leave("regex", true)
                 return true
             }
-        } catch _ as NSError {
+        } catch {
             found = false
         }
         
@@ -77,6 +78,7 @@ public prefix func %!(pattern:String) -> ParserRule {
         return false
     }
 }
+#endif
 
 // match a literal string
 prefix operator %


### PR DESCRIPTION
On Linux, building swift-parser-generator fails on two lines:

* catch _ as NSError (NSError does not appear to exist, just replace with 'catch')
* Stuff related to NSRegularExpression

This commit fixes the first and disables regular expressions on Linux for now.