### PR TITLE
Implement Packrat caching and split grammar definition from parsing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,16 @@ import PackageDescription
 
 let package = Package(
 	name: "SwiftParser",
+
 	products: [
 		.library(name: "SwiftParser", targets: ["SwiftParser"]),
 	],
+
 	dependencies: [
 	],
+
 	targets: [
+		.testTarget(name: "SwiftParserTests", dependencies: ["SwiftParser"]),
 		.target(name: "SwiftParser", path: "Sources")
 	]
 )

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -50,8 +50,8 @@ open class Parser {
 	public var debugRules = false
 	public var captures: [ParserCapture] = []
 	public var currentCapture: ParserCapture?
-	public var last_capture: ParserCapture?
-	public var current_reader: Reader?
+	public var lastCapture: ParserCapture?
+	public var currentReader: Reader?
 	public var grammar: Grammar
 	internal var matches: [ParserRule: [Int: Bool]] = [:]
 
@@ -77,22 +77,22 @@ open class Parser {
 		matches.removeAll(keepingCapacity: false)
 		captures.removeAll(keepingCapacity: true)
 		currentCapture = nil
-		last_capture = nil
+		lastCapture = nil
 
 		let reader = StringReader(string: string)
 
 		if(grammar.startRule!.matches(self, reader)) {
-			current_reader = reader
+			currentReader = reader
 
 			for capture in captures {
-				last_capture = currentCapture
+				lastCapture = currentCapture
 				currentCapture = capture
 				capture.action(self)
 			}
 
-			current_reader = nil
+			currentReader = nil
 			currentCapture = nil
-			last_capture = nil
+			lastCapture = nil
 			matches.removeAll(keepingCapacity: false)
 			return true
 		}

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -1,46 +1,193 @@
-//
-//  Parser.swift
-//  SwiftParser
-//
-//  Created by Daniel Parnell on 17/06/2014.
-//  Copyright (c) 2014 Daniel Parnell. All rights reserved.
-//
-
 import Foundation
 
-public typealias ParserRule = (_ parser: Parser, _ reader: Reader) -> Bool
-public typealias ParserAction = () -> ()
+public typealias ParserFunction = (_ parser: Parser, _ reader: Reader) -> Bool
+public typealias ParserAction = (_ parser: Parser) -> ()
+public typealias ParserActionWithoutParameter = () -> ()
+
+/** Definition of a grammar for the parser. Can be reused between multiple parsings. */
+public class Grammar {
+	/** This rule determines what is seen as 'whitespace' by the '~~'  operator, which allows
+	whitespace between two following items.*/
+	public var whitespace: ParserRule = (" " | "\t" | "\r\n" | "\r" | "\n")*
+
+	/** The start rule for this grammar. */
+	public var startRule: ParserRule! = nil
+	internal var namedRules: [String: ParserRule] = [:]
+
+	public init() {
+	}
+
+	public init(_ creator: (Grammar) -> (ParserRule)) {
+		self.startRule = creator(self)
+	}
+
+	public subscript(name: String) -> ParserRule {
+		get {
+			return self.namedRules[name]!
+		}
+		set(newValue) {
+			self.namedRules[name] = newValue
+		}
+	}
+}
+
+open class Parser {
+	public struct ParserCapture : CustomStringConvertible {
+		public var start: Int
+		public var end: Int
+		public var action: ParserAction
+		let reader: Reader
+
+		var text: String {
+			return reader.substring(start, ending_at:end)
+		}
+
+		public var description: String {
+			return "[\(start),\(end):\(text)]"
+		}
+	}
+
+	public var debugRules = false
+	public var captures: [ParserCapture] = []
+	public var currentCapture: ParserCapture?
+	public var last_capture: ParserCapture?
+	public var current_reader: Reader?
+	public var grammar: Grammar
+	internal var matches: [ParserRule: [Int: Bool]] = [:]
+
+	public var text: String {
+		get {
+			if let capture = currentCapture {
+				return capture.text
+			}
+
+			return ""
+		}
+	}
+
+	public init() {
+		self.grammar = Grammar()
+	}
+
+	public init(grammar: Grammar) {
+		self.grammar = grammar
+	}
+
+	public func parse(_ string: String) -> Bool {
+		matches.removeAll(keepingCapacity: false)
+		captures.removeAll(keepingCapacity: true)
+		currentCapture = nil
+		last_capture = nil
+
+		let reader = StringReader(string: string)
+
+		if(grammar.startRule!.matches(self, reader)) {
+			current_reader = reader
+
+			for capture in captures {
+				last_capture = currentCapture
+				currentCapture = capture
+				capture.action(self)
+			}
+
+			current_reader = nil
+			currentCapture = nil
+			last_capture = nil
+			matches.removeAll(keepingCapacity: false)
+			return true
+		}
+
+		return false
+	}
+
+	var depth = 0
+
+	func leave(_ name: String) {
+		if(debugRules) {
+			self.out("-- \(name)")
+		}
+		depth -= 1
+	}
+
+	func leave(_ name: String, _ res: Bool) {
+		if(debugRules) {
+			self.out("-- \(name):\t\(res)")
+		}
+		depth -= 1
+	}
+
+	func enter(_ name: String) {
+		depth += 1
+		if(debugRules) {
+			self.out("++ \(name)")
+		}
+	}
+
+	func out(_ name: String) {
+		var spaces = ""
+		for _ in 0..<depth-1 {
+			spaces += "  "
+		}
+		print("\(spaces)\(name)")
+	}
+}
+
+public class ParserRule: Hashable {
+	internal var function: ParserFunction
+
+	public init(_ function: @escaping ParserFunction) {
+		self.function = function
+	}
+
+	public func matches(_ parser: Parser, _ reader: Reader) -> Bool {
+		return self.function(parser, reader)
+	}
+
+	public var hashValue: Int {
+		return ObjectIdentifier(self).hashValue
+	}
+
+	public static func ==(lhs: ParserRule, rhs: ParserRule) -> Bool {
+		return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+	}
+}
+
+public final class ParserMemoizingRule: ParserRule {
+	public override func matches(_ parser: Parser, _ reader: Reader) -> Bool {
+		let position = reader.position
+		if let m = parser.matches[self]?[position] {
+			return m
+		}
+		let r = self.function(parser, reader)
+
+		if parser.matches[self] == nil {
+			parser.matches[self] = [position: r]
+		}
+		else {
+			parser.matches[self]![position] = r
+		}
+		return r
+	}
+}
 
 // EOF operator
 postfix operator *!*
 
-public postfix func *!* (rule: @escaping ParserRule) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
-        return rule(parser, reader) && reader.eof()
+public postfix func *!* (rule: ParserRule) -> ParserRule {
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
+        return rule.matches(parser, reader) && reader.eof()
     }
 }
 
 // call a named rule - this allows for cycles, so be careful!
 prefix operator ^
 public prefix func ^(name:String) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+    return ParserMemoizingRule { (parser: Parser, reader: Reader) -> Bool in
+		// TODO: check stack to see if this named rule is already on there to prevent loops
         parser.enter("named rule: \(name)")
-        
-        // check to see if this would cause a recursive loop?
-        if(parser.current_named_rule != name) {
-            let old_named_rule = parser.current_named_rule
-            let rule = parser.named_rules[name]
-        
-            parser.current_named_rule = name
-            let result = rule!(parser, reader)
-            parser.current_named_rule = old_named_rule
-            
-            parser.leave("named rule: \(name)",result)
-            return result
-        }
-        
-        parser.leave("named rule: - blocked", false)
-        return false
+		let result = parser.grammar[name].function(parser, reader)
+		parser.leave("named rule: \(name)",result)
+		return result
     }
 }
 
@@ -48,7 +195,7 @@ public prefix func ^(name:String) -> ParserRule {
 #if !os(Linux)
 prefix operator %!
 public prefix func %!(pattern:String) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         parser.enter("regex '\(pattern)'")
         
         let pos = reader.position
@@ -87,7 +234,7 @@ public prefix func %(lit:String) -> ParserRule {
 }
 
 public func literal(_ string:String) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         parser.enter("literal '\(string)'")
         
         let pos = reader.position
@@ -109,7 +256,7 @@ public func literal(_ string:String) -> ParserRule {
 
 // match a range of characters eg: "0"-"9"
 public func - (left: Character, right: Character) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         parser.enter("range [\(left)-\(right)]")
         
         let pos = reader.position
@@ -129,9 +276,9 @@ public func - (left: Character, right: Character) -> ParserRule {
 }
 
 // invert match
-public prefix func !(rule: @escaping ParserRule) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
-        return !rule(parser, reader)
+public prefix func !(rule: ParserRule) -> ParserRule {
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
+        return !rule.matches(parser, reader)
     }
 }
 
@@ -141,8 +288,8 @@ public prefix func !(lit: String) -> ParserRule {
 
 // match one or more
 postfix operator +
-public postfix func + (rule: @escaping ParserRule) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+public postfix func + (rule: ParserRule) -> ParserRule {
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         let pos = reader.position
         var found = false
         var flag: Bool
@@ -150,7 +297,7 @@ public postfix func + (rule: @escaping ParserRule) -> ParserRule {
         parser.enter("one or more")
         
         repeat {
-            flag = rule(parser, reader)
+            flag = rule.matches(parser, reader)
             found = found || flag
         } while(flag)
         
@@ -170,15 +317,15 @@ public postfix func + (lit: String) -> ParserRule {
 
 // match zero or more
 postfix operator *
-public postfix func * (rule: @escaping ParserRule) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+public postfix func * (rule: ParserRule) -> ParserRule {
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         var flag: Bool
         var matched = false
         parser.enter("zero or more")
         
         repeat {
             let pos = reader.position
-            flag = rule(parser, reader)
+            flag = rule.matches(parser, reader)
             if(!flag) {
                 reader.seek(pos)
             } else {
@@ -197,12 +344,12 @@ public postfix func * (lit: String) -> ParserRule {
 
 // optional
 postfix operator /~
-public postfix func /~ (rule: @escaping ParserRule) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+public postfix func /~ (rule: ParserRule) -> ParserRule {
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         parser.enter("optionally")
         
         let pos = reader.position
-        if(!rule(parser, reader)) {
+        if(!rule.matches(parser, reader)) {
             reader.seek(pos)
         }
 
@@ -220,22 +367,22 @@ public func | (left: String, right: String) -> ParserRule {
     return literal(left) | literal(right)
 }
 
-public func | (left: String, right: @escaping ParserRule) -> ParserRule {
+public func | (left: String, right: ParserRule) -> ParserRule {
     return literal(left) | right
 }
 
-public func | (left: @escaping ParserRule, right: String) -> ParserRule {
+public func | (left: ParserRule, right: String) -> ParserRule {
     return left | literal(right)
 }
 
-public func | (left: @escaping ParserRule, right: @escaping ParserRule) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+public func | (left: ParserRule, right: ParserRule) -> ParserRule {
+    return ParserMemoizingRule { (parser: Parser, reader: Reader) -> Bool in
         parser.enter("|")
         let pos = reader.position
-        var result = left(parser, reader)
+        var result = left.matches(parser, reader)
         if(!result) {
 			reader.seek(pos)
-            result = right(parser, reader)
+            result = right.matches(parser, reader)
         }
     
         if(!result) {
@@ -249,14 +396,13 @@ public func | (left: @escaping ParserRule, right: @escaping ParserRule) -> Parse
 
 precedencegroup MinPrecedence {
 	associativity: left
-	lowerThan: AssignmentPrecedence
+	higherThan: AssignmentPrecedence
 }
 
 precedencegroup MaxPrecedence {
-	associativity: right
+	associativity: left
 	higherThan: MinPrecedence
 }
-
 
 // match all
 infix operator  ~ : MinPrecedence
@@ -265,18 +411,18 @@ public func ~ (left: String, right: String) -> ParserRule {
     return literal(left) ~ literal(right)
 }
 
-public func ~ (left: String, right: @escaping ParserRule) -> ParserRule {
+public func ~ (left: String, right: ParserRule) -> ParserRule {
     return literal(left) ~ right
 }
 
-public func ~ (left: @escaping ParserRule, right: String) -> ParserRule {
+public func ~ (left: ParserRule, right: String) -> ParserRule {
     return left ~ literal(right)
 }
 
-public func ~ (left : @escaping ParserRule, right: @escaping ParserRule) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+public func ~ (left : ParserRule, right: ParserRule) -> ParserRule {
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         parser.enter("~")
-        let res = left(parser, reader) && right(parser, reader)
+        let res = left.matches(parser, reader) && right.matches(parser, reader)
         parser.leave("~", res)
         return res
     }
@@ -284,14 +430,15 @@ public func ~ (left : @escaping ParserRule, right: @escaping ParserRule) -> Pars
 
 // on match
 infix operator => : MaxPrecedence
-public func => (rule : @escaping ParserRule, action: @escaping ParserAction) -> ParserRule {
-    return {(parser: Parser, reader: Reader) -> Bool in
+
+public func => (rule : ParserRule, action: @escaping ParserAction) -> ParserRule {
+    return ParserRule { (parser: Parser, reader: Reader) -> Bool in
         let start = reader.position
         let capture_count = parser.captures.count
         
         parser.enter("=>")
         
-        if(rule(parser, reader)) {
+        if(rule.matches(parser, reader)) {
             let capture = Parser.ParserCapture(start: start, end: reader.position, action: action, reader: reader)
             
             parser.captures.append(capture)
@@ -307,6 +454,12 @@ public func => (rule : @escaping ParserRule, action: @escaping ParserAction) -> 
     }
 }
 
+public func => (rule : ParserRule, action: @escaping ParserActionWithoutParameter) -> ParserRule {
+	return rule => { _ in
+		action()
+	}
+}
+
 /** The ~~ operator matches two following elements, optionally with whitespace (Parser.whitespace) in between. */
 infix operator  ~~ : MinPrecedence
 
@@ -314,147 +467,22 @@ public func ~~ (left: String, right: String) -> ParserRule {
 	return literal(left) ~~ literal(right)
 }
 
-public func ~~ (left: String, right: @escaping ParserRule) -> ParserRule {
+public func ~~ (left: String, right: ParserRule) -> ParserRule {
 	return literal(left) ~~ right
 }
 
-public func ~~ (left: @escaping ParserRule, right: String) -> ParserRule {
+public func ~~ (left: ParserRule, right: String) -> ParserRule {
 	return left ~~ literal(right)
 }
 
-public func ~~ (left : @escaping ParserRule, right: @escaping ParserRule) -> ParserRule {
-	return {(parser: Parser, reader: Reader) -> Bool in
-		return left(parser, reader) && parser.whitespace(parser, reader) && right(parser, reader)
+public func ~~ (left : ParserRule, right: ParserRule) -> ParserRule {
+	return ParserRule { (parser: Parser, reader: Reader) -> Bool in
+		return left.matches(parser, reader) && parser.grammar.whitespace.matches(parser, reader) && right.matches(parser, reader)
 	}
 }
 
 /** Parser rule that matches the given parser rule at least once, but possibly more */
-public postfix func ++ (left: @escaping ParserRule) -> ParserRule {
+public postfix func ++ (left: ParserRule) -> ParserRule {
 	return left ~~ left*
-}
-
-public typealias ParserRuleDefinition = () -> ParserRule
-
-infix operator <-
-
-public func <- (left: Parser, right: @escaping ParserRuleDefinition) -> () {
-    left.rule_definitions.append(right)
-}
-
-open class Parser {
-    public struct ParserCapture : CustomStringConvertible {
-        public var start: Int
-        public var end: Int
-        public var action: ParserAction
-        let reader:Reader
-
-		var text: String {
-            return reader.substring(start, ending_at:end)
-        }
-
-        public var description: String {
-            return "[\(start),\(end):\(text)]"
-        }
-    }
-    
-    public var rule_definition: ParserRuleDefinition?
-    public var rule_definitions: [ParserRuleDefinition] = []
-    public var start_rule: ParserRule?
-    public var debug_rules = false
-
-    public var captures: [ParserCapture] = []
-    public var current_capture:ParserCapture?
-    public var last_capture:ParserCapture?
-    public var current_reader:Reader?
-
-	var named_rules: Dictionary<String,ParserRule> = Dictionary<String,ParserRule>()
-    var current_named_rule = ""
-
-	/** This rule determines what is seen as 'whitespace' by the '~~'  operator, which allows whitespace between two
-	 following items.*/
-	public var whitespace: ParserRule = (" " | "\t" | "\r\n" | "\r" | "\n")*
-
-    public var text:String {
-        get {
-            if let capture = current_capture {
-                return capture.text
-            }
-            
-            return ""
-        }
-    }
-    
-    public init() {
-        rules()
-    }
-    
-    public init(rule_def: @escaping () -> ParserRule) {
-        rule_definition = rule_def
-    }
-    
-    public func add_named_rule(_ name:String, rule: @escaping ParserRule) {
-        named_rules[name] = rule
-    }
-    
-    open func rules() {
-        
-    }
-    
-    public func parse(_ string: String) -> Bool {
-        if(start_rule == nil) {
-            start_rule = rule_definition!()
-        }
-        
-        captures.removeAll(keepingCapacity: true)
-        current_capture = nil
-        last_capture = nil
-        
-        let reader = StringReader(string: string)
-        
-        if(start_rule!(self, reader)) {
-            current_reader = reader
-            
-            for capture in captures {
-                last_capture = current_capture
-                current_capture = capture
-                capture.action()
-            }
-
-            current_reader = nil
-            current_capture = nil
-            last_capture = nil
-            return true
-        }
-        
-        return false
-    }
-    
-    var depth = 0
-    func leave(_ name:String) {
-        if(debug_rules) {
-            self.out("-- \(name)")
-        }
-        depth -= 1
-    }
-    func leave(_ name:String, _ res:Bool) {
-        if(debug_rules) {
-            self.out("-- \(name):\t\(res)")
-        }
-        depth -= 1
-    }
-    func enter(_ name:String) {
-        depth += 1
-        if(debug_rules) {
-            self.out("++ \(name)")
-        }
-    }
-    func out(_ name:String) {
-        var spaces = ""
-        for _ in 0..<depth-1 {
-            spaces += "  "
-        }
-        print("\(spaces)\(name)")
-    }
-    
 }
 

--- a/SwiftParser.xcodeproj/project.pbxproj
+++ b/SwiftParser.xcodeproj/project.pbxproj
@@ -1,339 +1,449 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      "OBJ_1" = {
-         isa = "PBXProject";
-         attributes = {
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = "OBJ_2";
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "English";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en",
-         );
-         mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_12";
-         projectDirPath = ".";
-         targets = (
-            "SwiftParser::SwiftPMPackageDescription",
-            "SwiftParser::SwiftParser",
-         );
-      };
-      "OBJ_10" = {
-         isa = "PBXFileReference";
-         path = "StringReader.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_11" = {
-         isa = "PBXGroup";
-         children = (
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_12" = {
-         isa = "PBXGroup";
-         children = (
-            "SwiftParser::SwiftParser::Product",
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_15" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_16",
-            "OBJ_17",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      "OBJ_16" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk",
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_17" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk",
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Release";
-      };
-      "OBJ_18" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_19",
-         );
-      };
-      "OBJ_19" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_2" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_3",
-            "OBJ_4",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      "OBJ_21" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_22",
-            "OBJ_23",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      "OBJ_22" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-            );
-            INFOPLIST_FILE = "SwiftParser.xcodeproj/SwiftParser_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftParser";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "SwiftParser";
-         };
-         name = "Debug";
-      };
-      "OBJ_23" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-            );
-            INFOPLIST_FILE = "SwiftParser.xcodeproj/SwiftParser_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftParser";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "SwiftParser";
-         };
-         name = "Release";
-      };
-      "OBJ_24" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_25",
-            "OBJ_26",
-            "OBJ_27",
-         );
-      };
-      "OBJ_25" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_8";
-      };
-      "OBJ_26" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_9";
-      };
-      "OBJ_27" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
-      };
-      "OBJ_28" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_3" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode",
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      "OBJ_4" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode",
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_11",
-            "OBJ_12",
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_7" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_8",
-            "OBJ_9",
-            "OBJ_10",
-         );
-         name = "Sources";
-         path = "Sources";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_8" = {
-         isa = "PBXFileReference";
-         path = "Parser.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_9" = {
-         isa = "PBXFileReference";
-         path = "Reader.swift";
-         sourceTree = "<group>";
-      };
-      "SwiftParser::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_15";
-         buildPhases = (
-            "OBJ_18",
-         );
-         dependencies = (
-         );
-         name = "SwiftParserPackageDescription";
-         productName = "SwiftParserPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftParser::SwiftParser" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_21";
-         buildPhases = (
-            "OBJ_24",
-            "OBJ_28",
-         );
-         dependencies = (
-         );
-         name = "SwiftParser";
-         productName = "SwiftParser";
-         productReference = "SwiftParser::SwiftParser::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftParser::SwiftParser::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftParser.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-   };
-   rootObject = "OBJ_1";
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"SwiftParser::SwiftParserPackageTests::ProductTarget" /* SwiftParserPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_42 /* Build configuration list for PBXAggregateTarget "SwiftParserPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_45 /* PBXTargetDependency */,
+			);
+			name = SwiftParserPackageTests;
+			productName = SwiftParserPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		OBJ_22 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_28 /* SwiftParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* SwiftParserTests.swift */; };
+		OBJ_30 /* SwiftParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftParser::SwiftParser::Product" /* SwiftParser.framework */; };
+		OBJ_37 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_8 /* Parser.swift */; };
+		OBJ_38 /* Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Reader.swift */; };
+		OBJ_39 /* StringReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* StringReader.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		657BA80B1FA8BC8800AC9AE0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftParser::SwiftParser";
+			remoteInfo = SwiftParser;
+		};
+		657BA80C1FA8BC8900AC9AE0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftParser::SwiftParserTests";
+			remoteInfo = SwiftParserTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		OBJ_10 /* StringReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringReader.swift; sourceTree = "<group>"; };
+		OBJ_13 /* SwiftParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftParserTests.swift; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_8 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		OBJ_9 /* Reader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reader.swift; sourceTree = "<group>"; };
+		"SwiftParser::SwiftParser::Product" /* SwiftParser.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftParser.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftParser::SwiftParserTests::Product" /* SwiftParserTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = SwiftParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_29 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_30 /* SwiftParser.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_40 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_11 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_12 /* SwiftParserTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_12 /* SwiftParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_13 /* SwiftParserTests.swift */,
+			);
+			name = SwiftParserTests;
+			path = Tests/SwiftParserTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_14 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"SwiftParser::SwiftParserTests::Product" /* SwiftParserTests.xctest */,
+				"SwiftParser::SwiftParser::Product" /* SwiftParser.framework */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_11 /* Tests */,
+				OBJ_14 /* Products */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* Parser.swift */,
+				OBJ_9 /* Reader.swift */,
+				OBJ_10 /* StringReader.swift */,
+			);
+			path = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"SwiftParser::SwiftPMPackageDescription" /* SwiftParserPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_18 /* Build configuration list for PBXNativeTarget "SwiftParserPackageDescription" */;
+			buildPhases = (
+				OBJ_21 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftParserPackageDescription;
+			productName = SwiftParserPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftParser::SwiftParser" /* SwiftParser */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_33 /* Build configuration list for PBXNativeTarget "SwiftParser" */;
+			buildPhases = (
+				OBJ_36 /* Sources */,
+				OBJ_40 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftParser;
+			productName = SwiftParser;
+			productReference = "SwiftParser::SwiftParser::Product" /* SwiftParser.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftParser::SwiftParserTests" /* SwiftParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_24 /* Build configuration list for PBXNativeTarget "SwiftParserTests" */;
+			buildPhases = (
+				OBJ_27 /* Sources */,
+				OBJ_29 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_31 /* PBXTargetDependency */,
+			);
+			name = SwiftParserTests;
+			productName = SwiftParserTests;
+			productReference = "SwiftParser::SwiftParserTests::Product" /* SwiftParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "SwiftParser" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_14 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"SwiftParser::SwiftPMPackageDescription" /* SwiftParserPackageDescription */,
+				"SwiftParser::SwiftParserTests" /* SwiftParserTests */,
+				"SwiftParser::SwiftParser" /* SwiftParser */,
+				"SwiftParser::SwiftParserPackageTests::ProductTarget" /* SwiftParserPackageTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_21 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_22 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_27 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_28 /* SwiftParserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_36 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_37 /* Parser.swift in Sources */,
+				OBJ_38 /* Reader.swift in Sources */,
+				OBJ_39 /* StringReader.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_31 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftParser::SwiftParser" /* SwiftParser */;
+			targetProxy = 657BA80B1FA8BC8800AC9AE0 /* PBXContainerItemProxy */;
+		};
+		OBJ_45 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftParser::SwiftParserTests" /* SwiftParserTests */;
+			targetProxy = 657BA80C1FA8BC8900AC9AE0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_19 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_20 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftParser.xcodeproj/SwiftParserTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftParserTests;
+			};
+			name = Debug;
+		};
+		OBJ_26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftParser.xcodeproj/SwiftParserTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftParserTests;
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftParser.xcodeproj/SwiftParser_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftParser;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftParser;
+			};
+			name = Debug;
+		};
+		OBJ_35 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftParser.xcodeproj/SwiftParser_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftParser;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftParser;
+			};
+			name = Release;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_43 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_44 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_18 /* Build configuration list for PBXNativeTarget "SwiftParserPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_19 /* Debug */,
+				OBJ_20 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_2 /* Build configuration list for PBXProject "SwiftParser" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_24 /* Build configuration list for PBXNativeTarget "SwiftParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_25 /* Debug */,
+				OBJ_26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_33 /* Build configuration list for PBXNativeTarget "SwiftParser" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_34 /* Debug */,
+				OBJ_35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_42 /* Build configuration list for PBXAggregateTarget "SwiftParserPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_43 /* Debug */,
+				OBJ_44 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/SwiftParser.xcodeproj/xcshareddata/xcschemes/SwiftParser-Package.xcscheme
+++ b/SwiftParser.xcodeproj/xcshareddata/xcschemes/SwiftParser-Package.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftParser::SwiftParser"
+               BuildableName = "SwiftParser.framework"
+               BlueprintName = "SwiftParser"
+               ReferencedContainer = "container:SwiftParser.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftParser::SwiftParserTests"
+               BuildableName = "SwiftParserTests.xctest"
+               BlueprintName = "SwiftParserTests"
+               ReferencedContainer = "container:SwiftParser.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "SwiftParser::SwiftParser"
+            BuildableName = "SwiftParser.framework"
+            BlueprintName = "SwiftParser"
+            ReferencedContainer = "container:SwiftParser.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftParser.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
+++ b/SwiftParser.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
@@ -3,7 +3,7 @@
 <dict>
   <key>SchemeUserState</key>
   <dict>
-    <key>SwiftParser.xcscheme</key>
+    <key>SwiftParser-Package.xcscheme</key>
     <dict></dict>
   </dict>
   <key>SuppressBuildableAutocreation</key>

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -10,166 +10,137 @@ import XCTest
 import SwiftParser
 
 class SwiftParserTests: XCTestCase {
-    
-    class Calculator {
-        var stack: [Double] = []
-        var _negative = false
-        
-        var result: Double {
-        get { return stack[stack.count-1] }
-        }
-        
-        func performBinaryOperation(_ op: (_ left: Double, _ right: Double) -> Double) {
-            let right = stack.removeLast()
-            let left = stack.removeLast()
-            
-            stack.append(op(left, right))
-        }
-        
-        func add() {
-            performBinaryOperation({(left: Double, right: Double) -> Double in
-                return left + right
-                })
-        }
-        
-        func divide() {
-            performBinaryOperation({(left: Double, right: Double) -> Double in
-                return left / right
-                })
-        }
-        
-        func exponent() {
-            performBinaryOperation({(left: Double, right: Double) -> Double in
-                return pow(left, right)
-                })
-        }
-        
-        func multiply() {
-            performBinaryOperation({(left: Double, right: Double) -> Double in
-                return left * right
-                })
-            
-        }
-        
-        func subtract() {
-            performBinaryOperation({(left: Double, right: Double) -> Double in
-                return left - right
-                })
-            
-        }
-        
-        func negative() {
-            _negative = !_negative
-        }
-        
-        func pushNumber(_ text: String) {
-            var value: Double = 0
-            var decimal = -1
-            var counter = 0
-            for ch in text.utf8 {
-                if(ch == 46) {
-                    decimal = counter
-                } else {
-                    let digit: Int = Int(ch) - 48
-                    value = value * Double(10.0) + Double(digit)
-                    counter = counter + 1
-                }
-            }
-            
-            if(decimal >= 0) {
-                value = value / pow(10.0, Double(counter - decimal))
-            }
-            
-            if(_negative) {
-                value = -value
-            }
-            
-            stack.append(value)
-        }
-        
-    }
-    
-    class Arith: Parser {
-        var calculator = Calculator()
-        
-        func push() {
-            calculator.pushNumber(text)
-        }
-        
-        func add() {
-            calculator.add()
-        }
-        
-        func sub() {
-            calculator.subtract()
-        }
-        
-        func mul() {
-            calculator.multiply()
-        }
-        
-        func div() {
-            calculator.divide()
-        }
-        
-        override func rules() {
-            start_rule = (^"primary")*!*
-            
-            let number = ("0"-"9")+ => push
-            add_named_rule("primary",   rule: ^"secondary" ~ (("+" ~ ^"secondary" => add) | ("-" ~ ^"secondary" => sub))*)
-            add_named_rule("secondary", rule: ^"tertiary" ~ (("*" ~ ^"tertiary" => mul) | ("/" ~ ^"tertiary" => div))*)
-            add_named_rule("tertiary",  rule: ("(" ~ ^"primary" ~ ")") | number)
-        }
-    }
-    
-    // A recursive parser like the following will always fail as it results in an infinite recursive loop.  Code has been added to try to catch this, but you have been warned!
-    class RecursiveArith : Arith {
-        override func rules() {
-            start_rule = (^"term")*!*
-            
-            let num = ("0"-"9")+ => push
-            add_named_rule("term", rule: ((^"term" ~ "+" ~ ^"fact") => add) | ((^"term" ~ "-" ~ ^"fact") => sub) | ^"fact")
-            add_named_rule("fact", rule: ((^"fact" ~ "*" ~ ^"term") => mul) | ((^"fact" ~ "/" ~ ^"term") => div) | ("(" ~ ^"term" ~ ")") | num)
-        }
-    }
+	class Calculator {
+		var stack: [Double] = []
+		var _negative = false
 
-   
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testSimple() {
-        let a = Arith()
-        XCTAssert(a.parse("1+2"))
-        XCTAssertEqual(a.calculator.result, 3)
-    }
+		var result: Double {
+			get { return stack[stack.count-1] }
+		}
 
-    func testComplex() {
-        let a = Arith()
-        XCTAssert(a.parse("6*7-3+20/2-12+(30-5)/5"))
-        XCTAssertEqual(a.calculator.result, 42)
-    }
+		func performBinaryOperation(_ op: (_ left: Double, _ right: Double) -> Double) {
+			let right = stack.removeLast()
+			let left = stack.removeLast()
 
-    func testRecursiveSimple() {
-        let a = RecursiveArith()
-        XCTAssertFalse(a.parse("1+2"))
-    }
-    
-    func testRecursiveComplex() {
-        let a = RecursiveArith()
-        
-        XCTAssertFalse(a.parse("6*7-3+20/2-12+(30-5)/5"))
-    }
-    
-    func testShouldNotParse() {
-        let a = Arith()
-        XCTAssertFalse(a.parse("1+"))
-        XCTAssertFalse(a.parse("xxx"))
-    }
+			stack.append(op(left, right))
+		}
+
+		func add() {
+			performBinaryOperation({(left: Double, right: Double) -> Double in
+				return left + right
+			})
+		}
+
+		func divide() {
+			performBinaryOperation({(left: Double, right: Double) -> Double in
+				return left / right
+			})
+		}
+
+		func exponent() {
+			performBinaryOperation({(left: Double, right: Double) -> Double in
+				return pow(left, right)
+			})
+		}
+
+		func multiply() {
+			performBinaryOperation({(left: Double, right: Double) -> Double in
+				return left * right
+			})
+
+		}
+
+		func subtract() {
+			performBinaryOperation({(left: Double, right: Double) -> Double in
+				return left - right
+			})
+
+		}
+
+		func negative() {
+			_negative = !_negative
+		}
+
+		func pushNumber(_ text: String) {
+			var value: Double = 0
+			var decimal = -1
+			var counter = 0
+			for ch in text.utf8 {
+				if(ch == 46) {
+					decimal = counter
+				} else {
+					let digit: Int = Int(ch) - 48
+					value = value * Double(10.0) + Double(digit)
+					counter = counter + 1
+				}
+			}
+
+			if(decimal >= 0) {
+				value = value / pow(10.0, Double(counter - decimal))
+			}
+
+			if(_negative) {
+				value = -value
+			}
+
+			stack.append(value)
+		}
+
+	}
+
+	class Arith: Parser {
+		var calculator = Calculator()
+
+		func push(_ text: String) {
+			calculator.pushNumber(text)
+		}
+
+		func add() {
+			calculator.add()
+		}
+
+		func sub() {
+			calculator.subtract()
+		}
+
+		func mul() {
+			calculator.multiply()
+		}
+
+		func div() {
+			calculator.divide()
+		}
+
+		override init() {
+			super.init()
+
+			self.grammar = Grammar { [unowned self] g in
+				g["number"] = ("0"-"9")+ => { [unowned self] parser in self.push(parser.text) }
+
+				g["primary"] = ^"secondary" ~ (("+" ~ ^"secondary" => add) | ("-" ~ ^"secondary" => sub))*
+				g["secondary"] = ^"tertiary" ~ (("*" ~ ^"tertiary" => mul) | ("/" ~ ^"tertiary" => div))*
+				g["tertiary"] = ("(" ~ ^"primary" ~ ")") | ^"number"
+
+				return (^"primary")*!*
+			}
+		}
+	}
+
+	func testSimple() {
+		let a = Arith()
+		XCTAssert(a.parse("1+2"))
+		XCTAssertEqual(a.calculator.result, 3)
+	}
+
+	func testComplex() {
+		let a = Arith()
+		XCTAssert(a.parse("6*7-3+20/2-12+(30-5)/5"))
+		XCTAssertEqual(a.calculator.result, 42)
+	}
+
+	func testShouldNotParse() {
+		let a = Arith()
+		XCTAssertFalse(a.parse("1+"))
+		XCTAssertFalse(a.parse("xxx"))
+	}
 }


### PR DESCRIPTION
Hi @dparnell!

So I did a bit of work on the parser today:

* Updated the whole thing to use swiftier names (e.g. "debugRules" instead of "debug_rules")
* Split grammar definition from parsing, so you don't have to construct all parsing rules each time you want to parse something. 
* Nicer `grammar["rulename"] = rule` syntax to replace `add_named_rule` (this saves one set of parentheses)
* Add caching of parsing results (cf. Packrat). You can choose to wrap your parsing function inside a `ParserRule` to not cache results and `ParserMemoizingRule` to cache. From my testing, smaller expressions were slower to parse with caching enabled. I therefore only enabled memoization by default for named rule references (^"foo") and the choice operator (a | b).

Note, these changes require changes by users. I updated the tests and README as well. 