### PR TITLE
Add ability to throw errors from parser actions and a way to limit nesting depth

### DIFF
--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -128,19 +128,19 @@ class SwiftParserTests: XCTestCase {
 
 	func testSimple() {
 		let a = Arith()
-		XCTAssert(a.parse("1+2"))
+		XCTAssert(try a.parse("1+2"))
 		XCTAssertEqual(a.calculator.result, 3)
 	}
 
 	func testComplex() {
 		let a = Arith()
-		XCTAssert(a.parse("6*7-3+20/2-12+(30-5)/5"))
+		XCTAssert(try a.parse("6*7-3+20/2-12+(30-5)/5"))
 		XCTAssertEqual(a.calculator.result, 42)
 	}
 
 	func testShouldNotParse() {
 		let a = Arith()
-		XCTAssertFalse(a.parse("1+"))
-		XCTAssertFalse(a.parse("xxx"))
+		XCTAssertFalse(try a.parse("1+"))
+		XCTAssertFalse(try a.parse("xxx"))
 	}
 }


### PR DESCRIPTION
This adds the ability to throw errors from parser actions (aborting the parsing). 

Additionally it allows for an optional nesting depth check, so that malformed expressions cannot cause a stack overflow. By wrapping a ParserRule with the nest(rule) function, it will count towards the nesting depth. Each time before the rule is entered, the nesting depth is checked against the limit and an error is thrown if the limit is exceeded.